### PR TITLE
Bugfix: Leak on backpress on Android Q

### DIFF
--- a/app/src/main/java/com/android/musicplayer/presentation/playlist/PlaylistActivity.kt
+++ b/app/src/main/java/com/android/musicplayer/presentation/playlist/PlaylistActivity.kt
@@ -54,6 +54,9 @@ class PlaylistActivity : BaseSongPlayerActivity(), OnPlaylistAdapterListener {
         viewModel.getSongsFromDb()
     }
 
+    override fun onBackPressed() {
+        supportFinishAfterTransition()
+    }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)


### PR DESCRIPTION
```
┬───
│ GC Root: Global variable in native code
│
├─ android.app.Activity$1 instance
│    Leaking: UNKNOWN
│    Retaining 144471 bytes in 2589 objects
│    Library leak match: instance field android.app.Activity$1#this$0
│    Anonymous subclass of android.app.IRequestFinishCallback$Stub
│    this$0 instance of com.android.musicplayer.presentation.playlist.
│    PlaylistActivity with mDestroyed = true
│    ↓ Activity$1.this$0
│                 ~~~~~~
╰→ com.android.musicplayer.presentation.playlist.PlaylistActivity instance
​     Leaking: YES (ObjectWatcher was watching this because com.android.
​     musicplayer.presentation.playlist.PlaylistActivity received
​     Activity#onDestroy() callback and Activity#mDestroyed is true)
​     Retaining 143943 bytes in 2588 objects
​     key = 53381ff6-b343-4316-a264-7bd161c5b5bd
​     watchDurationMillis = 5133
​     retainedDurationMillis = 129
​     mApplication instance of com.android.musicplayer.MainApplication
​     mBase instance of androidx.appcompat.view.ContextThemeWrapper, not
​     wrapping known Android context

METADATA

Build.VERSION.SDK_INT: 29
Build.MANUFACTURER: Google
LeakCanary version: 2.5
App process name: com.android.musicplayer
Stats: LruCache[maxSize=3000,hits=2381,misses=40149,hitRate=5%]
RandomAccess[bytes=2016556,reads=40149,travel=10670705110,range=12583593,size=16
840151]
Analysis duration: 3597 ms
```

https://issuetracker.google.com/issues/139738913